### PR TITLE
Fix compilation of exploration_planner and path_follower

### DIFF
--- a/hector_exploration_planner/CMakeLists.txt
+++ b/hector_exploration_planner/CMakeLists.txt
@@ -117,14 +117,15 @@ include_directories(
 #   src/${PROJECT_NAME}/hector_exploration_planner.cpp
 # )
 add_library(${PROJECT_NAME} src/hector_exploration_planner.cpp)
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 add_library(hector_exploration_base_global_planner_plugin src/hector_exploration_base_global_planner_plugin.cpp)
+target_link_libraries(hector_exploration_base_global_planner_plugin ${catkin_LIBRARIES})
 
 ## Declare a cpp executable
 # add_executable(hector_exploration_planner_node src/hector_exploration_planner_node.cpp)
 
 ## Add cmake target dependencies of the executable/library
 ## as an example, message headers may need to be generated before nodes
-# add_dependencies(hector_exploration_planner_node hector_exploration_planner_generate_messages_cpp)
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
 add_dependencies(hector_exploration_base_global_planner_plugin ${PROJECT_NAME}_gencfg)
 

--- a/hector_exploration_planner/package.xml
+++ b/hector_exploration_planner/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.0</version>
   <description>hector_exploration_planner is a planner that can both plan paths to goal points and generate goals to explore unknown environments</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="kohlbrecher@sim.tu-darmstadt.de">Stefan Kohlbrecher</maintainer>
@@ -39,7 +39,7 @@
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>cmake_modules</build_depend>  
+  <build_depend>cmake_modules</build_depend>
   <build_depend>costmap_2d</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>geometry_msgs</build_depend>
@@ -70,7 +70,6 @@
     <!-- Other tools can request additional information be placed here -->
 
     <nav_core plugin="${prefix}/hector_exploration_base_global_planner_plugin.xml" />
-    <cpp cflags="-I${prefix}/include" lflags="-L${prefix}/lib -Wl,-rpath,${prefix}/lib -lhector_exploration_planner"/>
 
   </export>
 </package>

--- a/hector_path_follower/CMakeLists.txt
+++ b/hector_path_follower/CMakeLists.txt
@@ -103,19 +103,18 @@ include_directories(
 #   src/${PROJECT_NAME}/hector_path_follower.cpp
 # )
 add_library(${PROJECT_NAME} src/hector_path_follower.cpp)
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
 ## Declare a cpp executable
 # add_executable(hector_path_follower_node src/hector_path_follower_node.cpp)
-add_executable(hector_path_follower_node src/hector_path_follower_node.cpp src/hector_path_follower.cpp)
+add_executable(hector_path_follower_node src/hector_path_follower_node.cpp)
 
 ## Add cmake target dependencies of the executable/library
 ## as an example, message headers may need to be generated before nodes
 # add_dependencies(hector_path_follower_node hector_path_follower_generate_messages_cpp)
 
 ## Specify libraries to link a library or executable target against
-target_link_libraries(hector_path_follower_node
-  ${catkin_LIBRARIES}
-)
+target_link_libraries(hector_path_follower_node ${PROJECT_NAME})
 
 #############
 ## Install ##

--- a/hector_path_follower/package.xml
+++ b/hector_path_follower/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.0</version>
   <description>hector_path_follower provides a node that publishes Twist messages, following a path. Based on the pose_follower package</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="kohlbrecher@sim.tu-darmstadt.de">Stefan Kohlbrecher</maintainer>
@@ -55,7 +55,6 @@
     <!-- <metapackage/> -->
 
     <!-- Other tools can request additional information be placed here -->
-    <cpp cflags="-I${prefix}/include" lflags="-L${prefix}/lib -Wl,-rpath,${prefix}/lib -lhector_path_follower"/>
 
   </export>
 </package>

--- a/hector_path_follower/src/hector_path_follower.cpp
+++ b/hector_path_follower/src/hector_path_follower.cpp
@@ -117,7 +117,7 @@ namespace pose_follower {
 
   bool HectorPathFollower::computeVelocityCommands(geometry_msgs::Twist& cmd_vel){
 
-    if (global_plan_.size() == 0)
+    if (global_plan_.empty())
       return false;
 
     //get the current pose of the robot in the fixed frame
@@ -240,13 +240,13 @@ namespace pose_follower {
 
     //in the case that we're not rotating to our goal position and we have a non-holonomic robot
     //we'll need to command a rotational velocity that will help us reach our desired heading
-    
+
     //we want to compute a goal based on the heading difference between our pose and the target
-    double yaw_diff = headingDiff(pose1.getOrigin().x(), pose1.getOrigin().y(), 
+    double yaw_diff = headingDiff(pose1.getOrigin().x(), pose1.getOrigin().y(),
         pose2.getOrigin().x(), pose2.getOrigin().y(), tf::getYaw(pose2.getRotation()));
 
     //we'll also check if we can move more effectively backwards
-    double neg_yaw_diff = headingDiff(pose1.getOrigin().x(), pose1.getOrigin().y(), 
+    double neg_yaw_diff = headingDiff(pose1.getOrigin().x(), pose1.getOrigin().y(),
         pose2.getOrigin().x(), pose2.getOrigin().y(), M_PI + tf::getYaw(pose2.getRotation()));
 
     //check if its faster to just back up
@@ -275,14 +275,14 @@ namespace pose_follower {
     res.linear.x *= K_trans_;
     if(!holonomic_)
       res.linear.y = 0.0;
-    else    
+    else
       res.linear.y *= K_trans_;
     res.angular.z *= K_rot_;
 
     //make sure to bound things by our velocity limits
     double lin_overshoot = sqrt(res.linear.x * res.linear.x + res.linear.y * res.linear.y) / max_vel_lin_;
     double lin_undershoot = min_vel_lin_ / sqrt(res.linear.x * res.linear.x + res.linear.y * res.linear.y);
-    if (lin_overshoot > 1.0) 
+    if (lin_overshoot > 1.0)
     {
       res.linear.x /= lin_overshoot;
       res.linear.y /= lin_overshoot;
@@ -317,15 +317,15 @@ namespace pose_follower {
     transformed_plan.clear();
 
     try{
-      if (!global_plan.size() > 0)
+      if (global_plan_.empty())
       {
         ROS_ERROR("Received plan with zero length");
         return false;
       }
 
       tf::StampedTransform transform;
-      tf.lookupTransform(global_frame, ros::Time(), 
-          plan_pose.header.frame_id, plan_pose.header.stamp, 
+      tf.lookupTransform(global_frame, ros::Time(),
+          plan_pose.header.frame_id, plan_pose.header.stamp,
           plan_pose.header.frame_id, transform);
 
       tf::Stamped<tf::Pose> tf_pose;


### PR DESCRIPTION
Addresses the issue mentioned in #5 and also a clang compiler warning that indeed looks like a bug ([hector_path_follower.cpp L320](https://github.com/Maidbot/hector_exploration/commit/4faefff910466aaec3fb36ef9620497501a960f2#diff-20637e52768562de17b8cf688094a2c6R320))

Compilation after applying this patch has been tested under ROS Indigo on both Ubuntu 14.04.x and OS X El Capitan. I also ran the exploration functionality on Ubuntu. Looks good.
