### PR TITLE
Fix: Mismatching frame ids in the header & poses of exploration path

### DIFF
--- a/hector_exploration_node/src/exploration_node.cpp
+++ b/hector_exploration_node/src/exploration_node.cpp
@@ -59,7 +59,7 @@ public:
       costmap_2d_ros_->getRobotPose(robot_pose);
 
       planner_->doExploration(robot_pose, res.trajectory.poses);
-      res.trajectory.header.frame_id = "map";
+      res.trajectory.header.frame_id = costmap_2d_ros_->getGlobalFrameID();
       res.trajectory.header.stamp = ros::Time::now();
 
       if (exploration_plan_pub_.getNumSubscribers() > 0)


### PR DESCRIPTION
The code works only if the Global Frame id of the costmap is given as "map" and if any other global frame id is provided, there is a mismatch in the frame id string in the "header of path topic" and the "header of poses in the path topic". This creates error if we try to visualize the path in rviz window.

Hence I have modified the code to directly obtain the frame id from costmap_2d_ros_ object to fix the mismatch. Now the code works perfectly for me, for any given global frame id.

Link to Costmap2DROS Documentation: http://docs.ros.org/melodic/api/costmap_2d/html/classcostmap__2d_1_1Costmap2DROS.html

And thank you so much for providing this wonderful package as open source.